### PR TITLE
Refactor: Migrate to Vertex AI SDK from Google AI SDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,7 @@ render.experimental.xml
 *.keystore
 
 # Google Services (e.g. APIs or Firebase)
-google-services.json
+# google-services.json
 
 # Android Profiling
 *.hprof

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # Android AI app
 
-**TODO: Add your Gemini API Key in the file local.properties**
-GEM_API_KEY="YOUR_API_KEY"
-[Get Gemini API Key here](https://aistudio.google.com/app/apikey)
+## Read the blog with steps to generate the google-services.json file
+**TODO: Add your google-services.json file. Ensure it's at the root level of your app module ```app/google-services.json```**
+
+1. After registering your app, Firebase will generate the google-services.json file. 
+2. Click the button Download google-services.json. 
+3. In your Android Studio project, move the downloaded file google-services.json into the app module directory.
 
 # Demo App
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,15 @@
 # Android AI app
 
 ## Read the blog with steps to generate the google-services.json file
-**TODO: Add your google-services.json file. Ensure it's at the root level of your app module ```app/google-services.json```**
+[Medium blog post](https://andresand.medium.com/configuring-firebase-vertex-ai-in-your-android-app-748416599eee)
 
-1. After registering your app, Firebase will generate the google-services.json file. 
-2. Click the button Download google-services.json. 
-3. In your Android Studio project, move the downloaded file google-services.json into the app module directory.
+**Note: for the code to work you need a Firebase account and configure your google-services.json
+file. Ensure it's at the root level of your app module ```app/google-services.json```**
+
+1. After registering your app, Firebase will generate the google-services.json file.
+2. Click the button Download google-services.json.
+3. In your Android Studio project, move the downloaded file google-services.json into the app module
+   directory.
 
 # Demo App
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     alias(libs.plugins.jetbrainsKotlinAndroid)
     alias(libs.plugins.composeCompiler)
     id("org.jetbrains.kotlin.plugin.serialization") version "2.1.20" // Use Kotlin version
+    id("com.google.gms.google-services")
 }
 
 android {
@@ -73,6 +74,9 @@ dependencies {
     implementation(libs.coil.compose)
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.generativeai)
+
+    implementation(platform(libs.firebase.bom))
+    implementation(libs.firebase.vertexai)
 
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)

--- a/app/google-services.json
+++ b/app/google-services.json
@@ -1,0 +1,29 @@
+{
+  "project_info": {
+    "project_number": "1223",
+    "project_id": "Add your file here",
+    "storage_bucket": "Add your file here"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "Add your file here",
+        "android_client_info": {
+          "package_name": "com.androidai.gemini"
+        }
+      },
+      "oauth_client": [],
+      "api_key": [
+        {
+          "current_key": "Add your file here"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": []
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}

--- a/app/src/main/java/com/androidai/gemini/GenerativeViewModelFactory.kt
+++ b/app/src/main/java/com/androidai/gemini/GenerativeViewModelFactory.kt
@@ -6,15 +6,15 @@ import androidx.lifecycle.viewmodel.CreationExtras
 import com.androidai.gemini.chat.ChatViewModel
 import com.androidai.gemini.multimodal.PhotoReasoningViewModel
 import com.androidai.gemini.text.SummarizeViewModel
-import com.google.ai.client.generativeai.GenerativeModel
-import com.google.ai.client.generativeai.type.generationConfig
+import com.google.firebase.Firebase
+import com.google.firebase.vertexai.vertexAI
 
 val GenerativeViewModelFactory = object : ViewModelProvider.Factory {
     override fun <T : ViewModel> create(
         viewModelClass: Class<T>,
         extras: CreationExtras
     ): T {
-        val config = generationConfig {
+        val config = com.google.firebase.vertexai.type.generationConfig {
             temperature = 0.7f
         }
 
@@ -23,9 +23,8 @@ val GenerativeViewModelFactory = object : ViewModelProvider.Factory {
                 isAssignableFrom(SummarizeViewModel::class.java) -> {
                     // Initialize a GenerativeModel with the `gemini-flash` AI model
                     // for text generation
-                    val generativeModel = GenerativeModel(
-                        modelName = "gemini-1.5-flash-latest",
-                        apiKey = BuildConfig.GEM_API_KEY,
+                    val generativeModel = Firebase.vertexAI.generativeModel(
+                        modelName = "gemini-2.0-flash",
                         generationConfig = config
                     )
                     SummarizeViewModel(generativeModel)
@@ -34,9 +33,8 @@ val GenerativeViewModelFactory = object : ViewModelProvider.Factory {
                 isAssignableFrom(PhotoReasoningViewModel::class.java) -> {
                     // Initialize a GenerativeModel with the `gemini-flash` AI model
                     // for multimodal text generation
-                    val generativeModel = GenerativeModel(
-                        modelName = "gemini-1.5-flash-latest",
-                        apiKey = BuildConfig.GEM_API_KEY,
+                    val generativeModel = Firebase.vertexAI.generativeModel(
+                        modelName = "gemini-2.0-flash",
                         generationConfig = config
                     )
                     PhotoReasoningViewModel(generativeModel)
@@ -44,9 +42,8 @@ val GenerativeViewModelFactory = object : ViewModelProvider.Factory {
 
                 isAssignableFrom(ChatViewModel::class.java) -> {
                     // Initialize a GenerativeModel with the `gemini-flash` AI model for chat
-                    val generativeModel = GenerativeModel(
-                        modelName = "gemini-1.5-flash-latest",
-                        apiKey = BuildConfig.GEM_API_KEY,
+                    val generativeModel = Firebase.vertexAI.generativeModel(
+                        modelName = "gemini-2.0-flash",
                         generationConfig = config
                     )
                     ChatViewModel(generativeModel)

--- a/app/src/main/java/com/androidai/gemini/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/androidai/gemini/chat/ChatViewModel.kt
@@ -18,16 +18,16 @@ package com.androidai.gemini.chat
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.google.ai.client.generativeai.GenerativeModel
-import com.google.ai.client.generativeai.type.asTextOrNull
-import com.google.ai.client.generativeai.type.content
+import com.google.firebase.vertexai.GenerativeModel
+import com.google.firebase.vertexai.type.asTextOrNull
+import com.google.firebase.vertexai.type.content
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 
 class ChatViewModel(
-    generativeModel: GenerativeModel
+    private val generativeModel: GenerativeModel
 ) : ViewModel() {
     private val chat = generativeModel.startChat(
         history = listOf(

--- a/app/src/main/java/com/androidai/gemini/multimodal/PhotoReasoningViewModel.kt
+++ b/app/src/main/java/com/androidai/gemini/multimodal/PhotoReasoningViewModel.kt
@@ -3,8 +3,8 @@ package com.androidai.gemini.multimodal
 import android.graphics.Bitmap
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.google.ai.client.generativeai.GenerativeModel
-import com.google.ai.client.generativeai.type.content
+import com.google.firebase.vertexai.GenerativeModel
+import com.google.firebase.vertexai.type.content
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow

--- a/app/src/main/java/com/androidai/gemini/text/SummarizeViewModel.kt
+++ b/app/src/main/java/com/androidai/gemini/text/SummarizeViewModel.kt
@@ -2,7 +2,7 @@ package com.androidai.gemini.text
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.google.ai.client.generativeai.GenerativeModel
+import com.google.firebase.vertexai.GenerativeModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,4 +3,5 @@ plugins {
     alias(libs.plugins.androidApplication) apply false
     alias(libs.plugins.jetbrainsKotlinAndroid) apply false
     alias(libs.plugins.composeCompiler) apply false
+    id("com.google.gms.google-services") version "4.4.2" apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ activityCompose = "1.10.1"
 composeBom = "2025.03.01"
 generativeai = "0.9.0"
 navigationCompose = "2.8.9"
+firebaseBom = "33.12.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -34,6 +35,9 @@ androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 generativeai = { group = "com.google.ai.client.generativeai", name = "generativeai", version.ref = "generativeai" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
+firebase-appcheck = { module = "com.google.firebase:firebase-appcheck" }
+firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebaseBom" }
+firebase-vertexai = { module = "com.google.firebase:firebase-vertexai" }
 
 [plugins]
 composeCompiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }


### PR DESCRIPTION
This commit migrates the application from the Google AI SDK to the Vertex AI SDK.

Key changes:

-   Replaced `com.google.ai.client.generativeai.GenerativeModel` with `com.google.firebase.vertexai.GenerativeModel` for model interactions.
-   Utilized `Firebase.vertexAI.generativeModel` to instantiate `GenerativeModel`.
-   Updated model name to `gemini-2.0-flash` in `GenerativeViewModelFactory`
-   Added `google-services.json` file for Firebase integration.
- Added `firebase-vertexai` and `firebase-bom` to gradle dependency.
- Removed google api key reference in code, changed to firebase vertex ai reference.
- Updated imports to use `com.google.firebase.vertexai` and its sub-packages instead of `com.google.ai.client.generativeai`.
- Updated .gitignore to ignore google-services.json file. For demo purpose.